### PR TITLE
Basic collector of ast.FuncDecl annotated comments 

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package gotomd
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"strings"
+)
+
+func commentHasAnnotation(comment, prefix, annotation string) bool {
+	normalizedComment := strings.ToLower(strings.Trim(comment, " "))
+	normalizedAnnotation := strings.ToLower(annotation)
+	if strings.HasPrefix(normalizedComment, prefix) {
+		rest := normalizedComment[len(prefix)-1:]
+		annotations := strings.Split(rest, " ")
+		for _, annot := range annotations {
+			if normalizedAnnotation == annot {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func Collect(file, prefix, annotation string) []string {
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, file, nil, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fnComments := make([]string, 0)
+
+	for _, decl := range astFile.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok {
+			if fd.Doc == nil || len(fd.Doc.List) == 0 {
+				continue
+			}
+
+			docText := fd.Doc.Text()
+			comments := strings.Split(docText, "\n")
+			if len(comments) > 0 {
+				if commentHasAnnotation(comments[0], prefix, annotation) {
+					docTextWithoutAnnotation := strings.Join(comments[1:], "\n")
+					fnComments = append(fnComments, docTextWithoutAnnotation)
+				}
+			}
+		}
+	}
+
+	return fnComments
+}

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package gotomd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommentHasAnnotationTrue(t *testing.T) {
+	comment := "   prefix: test"
+	annotation := "Test"
+
+	got := commentHasAnnotation(comment, "prefix", annotation)
+
+	assert.True(t, got)
+}
+
+func TestCommentHasAnnotationFalseAnnotation(t *testing.T) {
+	comment := "   prefix: test"
+	annotation := "Tes"
+
+	got := commentHasAnnotation(comment, "prefix", annotation)
+
+	assert.False(t, got)
+}
+
+func TestCommentHasAnnotationFalseComent(t *testing.T) {
+	comment := "prfix: test"
+	annotation := "test"
+
+	got := commentHasAnnotation(comment, "prefix", annotation)
+
+	assert.False(t, got)
+}
+
+func TestCollector(t *testing.T) {
+	commentOnFuncWithNoParamsReturn :=
+		`   ## funcWithNoParamsReturn
+
+funcWithNoParamsReturn is a Go function.
+It returns an empty string.
+`
+	commentOnFuncWithParamsReturn :=
+		` ## funcWithParamsReturn
+   This function receives some arguments and returns the empty string.
+`
+
+	commentOnMethodOfReceiverNoParamsNoReturn :=
+		`### methodOfReceiverNoParamsNoReturn
+Method on Receiver object that will do nothing.
+`
+	wantVal := []string{commentOnFuncWithNoParamsReturn, commentOnFuncWithParamsReturn, commentOnMethodOfReceiverNoParamsNoReturn}
+
+	gotVal := Collect("./resources/test/foo.go", "revy-doc", "test")
+
+	fmt.Println(gotVal)
+	assert.Equal(t, wantVal, gotVal)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/explore-dev/go-to-md
+
+go 1.18
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/resources/test/foo.go
+++ b/resources/test/foo.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Explore.dev Unipessoal Lda. All Rights Reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package test
+
+// funcWithNoParamsNoReturn is a Go function.
+// It has an empty signature and body.
+func funcWithNoParamsNoReturn() { // comment at the header of the func
+	// comment inside of the func
+}
+
+func funcWithParamsNoReturn(s string) {
+}
+
+/*
+
+
+   revy-doc: test
+   ## funcWithNoParamsReturn
+*/
+// funcWithNoParamsReturn is a Go function.
+// It returns an empty string.
+func funcWithNoParamsReturn() string {
+	// This is a function
+	kf := func() string {
+		return ""
+	}
+	return kf()
+}
+
+//    revy-doc: test
+/* ## funcWithParamsReturn
+   This function receives some arguments and returns the empty string.
+*/
+func funcWithParamsReturn(i int, s string, rest ...string) string {
+	return ""
+}
+
+/*
+   revy-doc: ignoring
+### funcWithMultipleParamsReturn
+This comment on the function will be ignored.
+*/
+func funcWithMultipleParamsReturn(i, k int, s string, rest ...string) string {
+	return ""
+}
+
+func funcWithMultipleParamsMultipleReturn(i, k int, s string, rest ...string) (string, error) {
+	return "", nil
+}
+
+type Receiver struct{}
+
+/*
+revy-doc: test
+### methodOfReceiverNoParamsNoReturn
+Method on Receiver object that will do nothing.
+*/
+func (r *Receiver) methodOfReceiverNoParamsNoReturn() {
+
+}
+
+func (r *Receiver) methodOfReceiverNoParamsReturn() string {
+	return ""
+}


### PR DESCRIPTION
This PR introduces a basic collector over a Golang source file that will traverse over the FuncDecl objects and filter the comments which match a particular annotation.

[reviewpad-sig]: <>
[View on **Reviewpad**](https://beta.reviewpad.com/review/github.com/explore-dev/go-to-md/pull/2)
